### PR TITLE
adding bcrypt and chaning Id to ID

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -75,7 +75,8 @@ authController.checkUniqueness = (req, res, next) => {
 
 authController.addUser = (req, res, next) => {
   // add this user to the database. We want to get their user id.
-  const { firstName, username, password } = req.body;
+  const { firstName, username } = req.body;
+  const { hashPw } = res.locals;
   // console.log('Name and password received at authController.addUser: ', name, password);
 
   // query for the _id on users table that matches the received name and password
@@ -83,7 +84,7 @@ authController.addUser = (req, res, next) => {
     `INSERT INTO users (first_name, username, password)
     VALUES ($1, $2, $3)
     RETURNING *`;
-  const values = [firstName, username, password];
+  const values = [firstName, username, hashPw ];
 
   // console.log("the addUser query: ", query, "values: ", values);
   db.query(query, values, (error, result) => {
@@ -103,9 +104,9 @@ authController.addUser = (req, res, next) => {
 
 authController.logout = (req, res, next) => {
   try {
-    res.clearCookie('userId');
     const query = `DELETE FROM sessions WHERE cookie_id = ($1)`;
     const params = [req.cookies.ssid];
+    res.clearCookie('ssid');
     db.query(query, params, (error, result) => {
       if (error) return next({ log: `middleware error caught in authController.logout: ${error}` });
       return next();

--- a/server/controllers/bcryptController.js
+++ b/server/controllers/bcryptController.js
@@ -1,0 +1,26 @@
+const bcrypt = require('bcrypt');
+
+const bcryptController = {};
+
+bcryptController.hashPassword = (req, res, next) => {
+  const { password } = req.body;
+  const SALT_ROUNDS = 10;
+  bcrypt.hash(password, SALT_ROUNDS, (err, hash) => {
+    if (err) return next({log: `middleware error in bcryptController.hashPassword ${err}`});
+    res.locals.hashPw = hash;
+    return next();
+  });
+};
+
+bcryptController.verifyPassword = (req, res, next) => {
+  const { password } = req.body;
+  const { userPw } = res.locals;
+  bcrypt.compare(password, userPw, (err, result) => {
+    if (err) return next({ log: `middleware error in bcryptController.verifyPassword ${err}` });
+    if (result) return next();
+    else return res.status(203).send('Invalid password.');
+  });
+}
+
+
+module.exports = bcryptController;

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const cookieParser = require('cookie-parser');
 const authController = require('../controllers/authController.js');
 const listController = require('../controllers/listController.js');
+const bcryptController = require('../controllers/bcryptController.js');
 
 const app = express();
 app.use(cookieParser());
@@ -13,7 +14,8 @@ app.use(express.json());
 // vanilla log in
 router.put('/login',    
   authController.findUser,
-  authController.validatePassword,
+  // authController.validatePassword,
+  bcryptController.verifyPassword,
   authController.createSession,
   authController.setCookie,
   // listController.getList,
@@ -27,7 +29,8 @@ router.put('/login',
 
 router.put('/signup',
   authController.getAllUsers,
-  authController.checkUniqueness,    
+  authController.checkUniqueness,   
+  bcryptController.hashPassword, 
   authController.addUser,
   // authController.findUser,
   authController.createSession,
@@ -54,7 +57,6 @@ router.get('/users',
   authController.getAllUsers,
   (req, res) => res.status(200).json(res.locals.allUsers)
 )
-
 
 /* 
 TODO

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -20,10 +20,10 @@ router.put('/login',
   authController.setCookie,
   // listController.getList,
   (req, res) => res.status(200).json({
-    userId: res.locals.userId,
+    userID: res.locals.userId,
     firstName: res.locals.firstName,
     username: res.locals.username,
-    householdId: res.locals.householdId
+    householdID: res.locals.householdId
   }) // todo: what should be sent back on the response?
 );
 
@@ -37,7 +37,7 @@ router.put('/signup',
   authController.setCookie,
   // listController.getList,
   (req, res) => res.status(200).json({
-    userId: res.locals.userId,
+    userID: res.locals.userId,
     firstName: res.locals.firstName,
     username: res.locals.username,
   }) // todo: what should be sent back on the response?


### PR DESCRIPTION
**Issue:** 
- Original code did not encrypt passwords 
- responses formatted IDs as `Id` rather than `ID`

**Changes in PR:**
- Uses bcrypt to encrypt passwords when the user signs up
- Uses bcrypt to compare passwords when the user logs in 
- Changes `Id` to `ID` on endpoint responses